### PR TITLE
Add an unsafe low level API for V8

### DIFF
--- a/ClearScript.sln
+++ b/ClearScript.sln
@@ -171,6 +171,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClearScriptConsole", "NetSt
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClearScript.V8.ICUData", "NetStandard\ClearScript.V8.ICUData\ClearScript.V8.ICUData.csproj", "{47FC5CB5-A6F2-4FEE-99F8-A758D3A7373C}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Unity", "Unity", "{C2F3A73A-B503-48AB-88CF-600252015008}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PackageBuilder", "Unity\PackageBuilder\PackageBuilder.csproj", "{D21DFD33-8138-4EBA-AE97-A7CB0B38D56B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -293,6 +297,10 @@ Global
 		{47FC5CB5-A6F2-4FEE-99F8-A758D3A7373C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{47FC5CB5-A6F2-4FEE-99F8-A758D3A7373C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{47FC5CB5-A6F2-4FEE-99F8-A758D3A7373C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D21DFD33-8138-4EBA-AE97-A7CB0B38D56B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D21DFD33-8138-4EBA-AE97-A7CB0B38D56B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D21DFD33-8138-4EBA-AE97-A7CB0B38D56B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D21DFD33-8138-4EBA-AE97-A7CB0B38D56B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -327,6 +335,7 @@ Global
 		{EF6090B9-7349-4868-9C43-D7D3F048C54F} = {48C9730D-CA6C-47ED-B72C-DB9B6EE24D47}
 		{C0E7BCAD-B4B3-4291-A87A-384D5F99C413} = {3047C214-A12B-4C8B-AEED-021FAA0B4CD3}
 		{47FC5CB5-A6F2-4FEE-99F8-A758D3A7373C} = {3047C214-A12B-4C8B-AEED-021FAA0B4CD3}
+		{D21DFD33-8138-4EBA-AE97-A7CB0B38D56B} = {C2F3A73A-B503-48AB-88CF-600252015008}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3BAF1393-35E4-45F1-AC56-4A22646B56E5}

--- a/ClearScript/V8/SplitProxy/IV8HostObject.cs
+++ b/ClearScript/V8/SplitProxy/IV8HostObject.cs
@@ -1,0 +1,116 @@
+﻿using System;
+
+namespace Microsoft.ClearScript.V8.SplitProxy
+{
+    /// <summary>
+    /// Implement this interface to talk to ClearScript's native wrapper around V8 directly.
+    /// </summary>
+    public interface IV8HostObject
+    {
+        /// <summary>
+        /// Implement this to support getting the values of named properties.
+        /// </summary>
+        /// <param name="name">The name of the property JavaScript wants the value of.</param>
+        /// <param name="value">Write the value of the property here.</param>
+        /// <param name="isConst">If you set this to to true, V8 will cache the value not ask for it
+        /// again.</param>
+        void GetNamedProperty(StdString name, V8Value value, out bool isConst) =>
+            throw new NotImplementedException($"Named property {name.ToString()} is not implemented");
+
+        /// <summary>
+        /// Implement this to support setting the values of named properties.
+        /// </summary>
+        /// <param name="name">The name of the property JavaScript wants to set.</param>
+        /// <param name="value">The value JavaScript wants to set the property to.</param>
+        void SetNamedProperty(StdString name, V8Value.Decoded value) =>
+            throw new NotImplementedException($"Named property {name.ToString()} is not implemented");
+
+        /// <summary>
+        /// Implement this to support deleting named properties.
+        /// </summary>
+        /// <param name="name">The name of the property JavaScript wants to delete.</param>
+        /// <returns>TODO</returns>
+        bool DeleteNamedProperty(StdString name) =>
+            throw new NotImplementedException($"Named property {name.ToString()} is not implemented");
+
+        /// <summary>
+        /// Implement this to support getting the values of indexed properties.
+        /// </summary>
+        /// <param name="index">The index of the property JavaScript wants the value of.</param>
+        /// <param name="value">Write the value of the property here.</param>
+        void GetIndexedProperty(int index, V8Value value) =>
+            throw new NotImplementedException($"Indexed property {index} is not implemented");
+
+        /// <summary>
+        /// Implement this to support setting the values of indexed properties.
+        /// </summary>
+        /// <param name="index">The index of the property JavaScript wants to set.</param>
+        /// <param name="value">The value JavaScript wants to set the property to.</param>
+        void SetIndexedProperty(int index, V8Value.Decoded value) =>
+            throw new NotImplementedException($"Indexed property {index} is not implemented");
+
+        /// <summary>
+        /// Implement this to support deleting indexed properties.
+        /// </summary>
+        /// <param name="index">The index of the property JavaScript wants to delete.</param>
+        /// <returns>TODO</returns>
+        bool DeleteIndexedProperty(int index) =>
+            throw new NotImplementedException($"Indexed property {index} is not implemented");
+
+        /// <summary>
+        /// Implement this to support being enumerated.
+        /// </summary>
+        /// <param name="result">Write the enumerator here.</param>
+        /// <remarks>
+        /// The enumerator class should implement <see cref="IV8HostObject"/> and implement MoveNext(),
+        /// ScriptableDispose(), and CurrentValue.
+        /// </remarks>
+        void GetEnumerator(V8Value result) =>
+            throw new NotImplementedException("Enumerator is not implemented");
+
+        /// <summary>
+        /// Implement this to support being async enumerated.
+        /// </summary>
+        /// <param name="result">Write the async enumerator here.</param>
+        void GetAsyncEnumerator(V8Value result) =>
+            throw new NotImplementedException("Async enumerator is not implemented");
+
+        /// <summary>
+        /// Implement this to support listing of all your named proeprties.
+        /// </summary>
+        /// <param name="names">Write the names of your properties here.</param>
+        void GetNamedPropertyNames(StdStringArray names) =>
+            throw new NotImplementedException("Listing named properties is not implemented");
+
+        /// <summary>
+        /// Implement this to support listing all your indexed properties.
+        /// </summary>
+        /// <param name="indices">Write the indices of your properties here.</param>
+        void GetIndexedPropertyIndices(StdInt32Array indices) =>
+            throw new NotImplementedException("Listing indexed properties is not implemented");
+
+        /// <summary>
+        /// I don't know when ClearScript calls this.
+        /// </summary>
+        /// <param name="name">The name of the method JavaScript wants to invoke.</param>
+        /// <param name="args">The arguments JavaScript is passing to the method.</param>
+        /// <param name="result">Write the return value, if not <see cref="void"/>, of the method here.
+        /// </param>
+        void InvokeMethod(StdString name, ReadOnlySpan<V8Value.Decoded> args, V8Value result)
+        {
+            GetNamedProperty(name, result, out _);
+            object method = result.Decode().GetHostObject();
+            result.SetNonexistent();
+            ((InvokeHostObject)method)(args, result);
+        }
+    }
+
+    /// <summary>
+    /// Return a delegate of this type from a property to tell JavaScript that it is a callable
+    /// function.
+    /// </summary>
+    /// <param name="args">The arguments JavaScript will pass to your method when invoking it.</param>
+    /// <param name="result">Write the return value, if not <see cref="void"/>, of the method here.
+    /// </param>
+    public delegate void InvokeHostObject(ReadOnlySpan<V8Value.Decoded> args, V8Value result);
+}

--- a/ClearScript/V8/SplitProxy/IV8SplitProxyNative.cs
+++ b/ClearScript/V8/SplitProxy/IV8SplitProxyNative.cs
@@ -19,6 +19,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
 
         StdString.Ptr StdString_New(string value);
         string StdString_GetValue(StdString.Ptr pString);
+        void StdString_GetValue(StdString.Ptr pString, out IntPtr value, out int length);
         void StdString_SetValue(StdString.Ptr pString, string value);
         void StdString_Delete(StdString.Ptr pString);
 
@@ -171,6 +172,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         void V8Context_AwaitDebuggerAndPause(V8Context.Handle hContext);
         void V8Context_CancelAwaitDebugger(V8Context.Handle hContext);
         object V8Context_ExecuteCode(V8Context.Handle hContext, string resourceName, string sourceMapUrl, ulong uniqueId, DocumentKind documentKind, IntPtr pDocumentInfo, string code, bool evaluate);
+        void V8Context_ExecuteCode(V8Context.Handle hContext, StdString.Ptr pResourceName, StdString.Ptr pSourceMapUrl, ulong uniquId, DocumentKind documentKind, IntPtr pDocumentInfo, StdString.Ptr pCode, bool evaluate, V8Value.Ptr pResult);
         V8Script.Handle V8Context_Compile(V8Context.Handle hContext, string resourceName, string sourceMapUrl, ulong uniqueId, DocumentKind documentKind, IntPtr pDocumentInfo, string code);
         V8Script.Handle V8Context_CompileProducingCache(V8Context.Handle hContext, string resourceName, string sourceMapUrl, ulong uniqueId, DocumentKind documentKind, IntPtr pDocumentInfo, string code, V8CacheKind cacheKind, out byte[] cacheBytes);
         V8Script.Handle V8Context_CompileConsumingCache(V8Context.Handle hContext, string resourceName, string sourceMapUrl, ulong uniqueId, DocumentKind documentKind, IntPtr pDocumentInfo, string code, V8CacheKind cacheKind, byte[] cacheBytes, out bool cacheAccepted);
@@ -199,6 +201,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         #region V8 object methods
 
         object V8Object_GetNamedProperty(V8Object.Handle hObject, string name);
+        void V8Object_GetNamedProperty(V8Object.Handle hObject, StdString.Ptr pName, V8Value.Ptr pValue);
         bool V8Object_TryGetNamedProperty(V8Object.Handle hObject, string name, out object value);
         void V8Object_SetNamedProperty(V8Object.Handle hObject, string name, object value);
         bool V8Object_DeleteNamedProperty(V8Object.Handle hObject, string name);
@@ -208,8 +211,10 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         bool V8Object_DeleteIndexedProperty(V8Object.Handle hObject, int index);
         int[] V8Object_GetPropertyIndices(V8Object.Handle hObject);
         object V8Object_Invoke(V8Object.Handle hObject, bool asConstructor, object[] args);
+        void V8Object_Invoke(V8Object.Handle hObject, bool asConstructor, StdV8ValueArray.Ptr pArgs, V8Value.Ptr pResult);
         object V8Object_InvokeMethod(V8Object.Handle hObject, string name, object[] args);
         void V8Object_GetArrayBufferOrViewInfo(V8Object.Handle hObject, out IV8Object arrayBuffer, out ulong offset, out ulong size, out ulong length);
+        void V8Object_GetArrayBufferOrViewInfo(V8Object.Handle hObject, V8Value.Ptr pArrayBuffer, out ulong offset, out ulong size, out ulong length);
         void V8Object_InvokeWithArrayBufferOrViewData(V8Object.Handle hObject, IntPtr pAction);
 
         #endregion

--- a/ClearScript/V8/SplitProxy/Uint8Array.cs
+++ b/ClearScript/V8/SplitProxy/Uint8Array.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.ClearScript.V8.SplitProxy
+{
+    /// <summary>
+    /// Wraps a Uint8Array, an array of <see cref="byte"/>.
+    /// </summary>
+    public readonly ref struct Uint8Array
+    {
+        private readonly V8Object.Handle ptr;
+
+        internal Uint8Array(V8Object.Handle pArray)
+        {
+            ptr = pArray;
+            using var arrayBuffer = V8Value.New();
+
+            V8SplitProxyNative.Instance.V8Object_GetArrayBufferOrViewInfo(pArray, arrayBuffer.ptr,
+                out _, out _, out ulong length);
+
+            Length = (int)length;
+        }
+
+        /// <summary>
+        /// Copy the contents of the wrapped Uint8Array to a managed <see cref="byte"/> array.
+        /// </summary>
+        /// <param name="array">The destination array. It must be large enough to contain the entire
+        /// contents of the wrapped Uint8Array.</param>
+        public void CopyTo(byte[] array)
+        {
+            int length = Length;
+
+            if (length > array.Length)
+                throw new IndexOutOfRangeException(
+                    $"Tried to copy {length} items to a {array.Length} item array");
+
+            // TODO: Don't allocate a lambda every time.
+            IntPtr pAction = V8ProxyHelpers.AddRefHostObject(new Action<IntPtr>(data =>
+                Marshal.Copy(data, array, 0, length)));
+
+            try
+            {
+                V8SplitProxyNative.Instance.V8Object_InvokeWithArrayBufferOrViewData(ptr, pAction);
+            }
+            finally
+            {
+                V8ProxyHelpers.ReleaseHostObject(pAction);
+            }
+        }
+
+        /// <summary>
+        /// The length of the wrapped Uint8Array.
+        /// </summary>
+        public int Length { get; }
+    }
+}

--- a/ClearScript/V8/SplitProxy/V8ContextProxyImpl.cs
+++ b/ClearScript/V8/SplitProxy/V8ContextProxyImpl.cs
@@ -11,7 +11,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
     {
         private V8EntityHolder holder;
 
-        private V8Context.Handle Handle => (V8Context.Handle)holder.Handle;
+        internal V8Context.Handle Handle => (V8Context.Handle)holder.Handle;
 
         public V8ContextProxyImpl(V8IsolateProxy isolateProxy, string name, V8ScriptEngineFlags flags, int debugPort)
         {

--- a/ClearScript/V8/SplitProxy/V8Function.cs
+++ b/ClearScript/V8/SplitProxy/V8Function.cs
@@ -1,0 +1,79 @@
+using System;
+
+namespace Microsoft.ClearScript.V8.SplitProxy
+{
+    /// <summary>
+    /// Wraps a JavaScript function.
+    /// </summary>
+    public sealed class V8Function : IDisposable
+    {
+        private V8EntityHolder holder;
+
+        /// <summary>
+        /// Evaluate a JavaScript expression and cast it to a function.
+        /// </summary>
+        /// <param name="code">A JavaScript expression that must evaluate to a function object.</param>
+        /// <remarks>
+        /// Currently, V8Function can only be created from within a callback from JavaScript.
+        /// </remarks>
+        /// <exception cref="InvalidCastException">If the JavaScript expression sis not evaluate to a
+        /// function object.</exception>
+        /// <exception cref="NotSupportedException">If the constructor is called not from within a
+        /// callback from JavaScript.</exception>
+        public V8Function(string code)
+        {
+            if (ScriptEngine.Current == null)
+                throw new NotSupportedException(
+                    "Currently, V8Function can only be created from within a callback from JavaScript.");
+
+            holder = new V8EntityHolder(nameof(V8Function), () => V8SplitProxyNative.Invoke(instance =>
+            {
+                var engine = (V8ScriptEngine)ScriptEngine.Current;
+                var contextProxy = (V8ContextProxyImpl)engine.ContextProxy;
+                using var resourceName = new StdString(null);
+                using var sourceMapUrl = new StdString(null);
+                using var stdCode = new StdString(code);
+                using var result = V8Value.New();
+
+                instance.V8Context_ExecuteCode(contextProxy.Handle, resourceName.ptr, sourceMapUrl.ptr,
+                    (ulong)GetHashCode(), DocumentKind.Script, IntPtr.Zero, stdCode.ptr, true,
+                    result.ptr);
+
+                var decoded = result.Decode();
+
+                if (decoded.Subtype != V8Value.Subtype.Function)
+                {
+                    if (decoded.Type == V8Value.Type.V8Object)
+                        instance.V8Entity_DestroyHandle((V8Entity.Handle)decoded.PtrOrHandle);
+
+                    throw new InvalidCastException(
+                        "The JavaScript expression did not evaluate to a function object");
+                }
+
+                return (V8Object.Handle)decoded.PtrOrHandle;
+            }));
+        }
+
+        /// <summary>
+        /// Release the wrapped JavaScript function, so it can be destroyed by the V8 garbace collector.
+        /// </summary>
+        public void Dispose()
+        {
+            V8EntityHolder.Destroy(ref holder);
+        }
+
+        /// <summary>
+        /// Invoke the wrapped JavaScript function.
+        /// </summary>
+        /// <param name="args">The list of arguments to pass to the function.</param>
+        /// <param name="result">The function will write its return value, if any, here.</param>
+        public void Invoke(StdV8ValueArray args, V8Value result)
+        {
+            StdV8ValueArray.Ptr argsPtr = args.ptr;
+            V8Value.Ptr resultPtr = result.ptr;
+
+            V8SplitProxyNative.Invoke(instance =>
+                instance.V8Object_Invoke((V8Object.Handle)holder.Handle, false, argsPtr, resultPtr));
+        }
+    }
+}

--- a/ClearScript/V8/SplitProxy/V8SplitProxyNative.Common.tt
+++ b/ClearScript/V8/SplitProxy/V8SplitProxyNative.Common.tt
@@ -90,6 +90,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 return Marshal.PtrToStringUni(pValue, length);
             }
 
+            void IV8SplitProxyNative.StdString_GetValue(StdString.Ptr pString, out IntPtr value, out int length)
+            {
+                value = StdString_GetValue(pString, out length);
+            }
+
             void IV8SplitProxyNative.StdString_SetValue(StdString.Ptr pString, string value)
             {
                 StdString_SetValue(pString, value, value.Length);
@@ -742,6 +747,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Context_ExecuteCode(V8Context.Handle hContext, StdString.Ptr pResourceName, StdString.Ptr pSourceMapUrl, ulong uniquId, DocumentKind documentKind, IntPtr pDocumentInfo, StdString.Ptr pCode, bool evaluate, V8Value.Ptr pResult)
+            {
+                V8Context_ExecuteCode(hContext, pResourceName, pSourceMapUrl, uniquId, documentKind, pDocumentInfo, pCode, evaluate, pResult);
+            }
+
             V8Script.Handle IV8SplitProxyNative.V8Context_Compile(V8Context.Handle hContext, string resourceName, string sourceMapUrl, ulong uniqueId, DocumentKind documentKind, IntPtr pDocumentInfo, string code)
             {
                 using (var resourceNameScope = StdString.CreateScope(resourceName))
@@ -939,6 +949,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Object_GetNamedProperty(V8Object.Handle hObject, StdString.Ptr pName, V8Value.Ptr pValue)
+            {
+                V8Object_GetNamedProperty(hObject, pName, pValue);
+            }
+
             bool IV8SplitProxyNative.V8Object_TryGetNamedProperty(V8Object.Handle hObject, string name, out object value)
             {
                 using (var nameScope = StdString.CreateScope(name))
@@ -1028,6 +1043,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Object_Invoke(V8Object.Handle hObject, bool asConstructor, StdV8ValueArray.Ptr pArgs, V8Value.Ptr pResult)
+            {
+                V8Object_Invoke(hObject, asConstructor, pArgs, pResult);
+            }
+
             object IV8SplitProxyNative.V8Object_InvokeMethod(V8Object.Handle hObject, string name, object[] args)
             {
                 using (var nameScope = StdString.CreateScope(name))
@@ -1050,6 +1070,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                     V8Object_GetArrayBufferOrViewInfo(hObject, arrayBufferScope.Value, out offset, out size, out length);
                     arrayBuffer = (IV8Object)V8Value.Get(arrayBufferScope.Value);
                 }
+            }
+
+            void IV8SplitProxyNative.V8Object_GetArrayBufferOrViewInfo(V8Object.Handle hObject, V8Value.Ptr pArrayBuffer, out ulong offset, out ulong size, out ulong length)
+            {
+                V8Object_GetArrayBufferOrViewInfo(hObject, pArrayBuffer, out offset, out size, out length);
             }
 
             void IV8SplitProxyNative.V8Object_InvokeWithArrayBufferOrViewData(V8Object.Handle hObject, IntPtr pAction)

--- a/ClearScript/V8/SplitProxy/V8SplitProxyNative.Generated.cs
+++ b/ClearScript/V8/SplitProxy/V8SplitProxyNative.Generated.cs
@@ -4,6 +4,11 @@
 
 
 
+
+
+
+
+
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
@@ -19,79 +24,95 @@ namespace Microsoft.ClearScript.V8.SplitProxy
             var architecture = RuntimeInformation.ProcessArchitecture;
 
             
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 
+
                 if (architecture == Architecture.X86)
                 {
                     return new Impl_Windows_X86();
                 }
 
                 
+
                 if (architecture == Architecture.X64)
                 {
                     return new Impl_Windows_X64();
                 }
 
                 
+
                 if (architecture == Architecture.Arm64)
                 {
                     return new Impl_Windows_Arm64();
                 }
 
                 
+
                 throw new PlatformNotSupportedException("Unsupported process architecture");
             }
 
             
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 
+
                 if (architecture == Architecture.X64)
                 {
                     return new Impl_Linux_X64();
                 }
 
                 
+
                 if (architecture == Architecture.Arm64)
                 {
                     return new Impl_Linux_Arm64();
                 }
 
                 
+
                 if (architecture == Architecture.Arm)
                 {
                     return new Impl_Linux_Arm();
                 }
 
                 
+
                 throw new PlatformNotSupportedException("Unsupported process architecture");
             }
 
             
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 
+
                 if (architecture == Architecture.X64)
                 {
                     return new Impl_OSX_X64();
                 }
 
                 
+
                 if (architecture == Architecture.Arm64)
                 {
                     return new Impl_OSX_Arm64();
                 }
 
                 
+
                 throw new PlatformNotSupportedException("Unsupported process architecture");
             }
 
             
+
             throw new PlatformNotSupportedException("Unsupported operating system");
         }
 
         
+
         #region Nested type: Impl_Windows_X86
 
         private sealed class Impl_Windows_X86 : IV8SplitProxyNative
@@ -132,6 +153,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 return Marshal.PtrToStringUni(pValue, length);
             }
 
+            void IV8SplitProxyNative.StdString_GetValue(StdString.Ptr pString, out IntPtr value, out int length)
+            {
+                value = StdString_GetValue(pString, out length);
+            }
+
             void IV8SplitProxyNative.StdString_SetValue(StdString.Ptr pString, string value)
             {
                 StdString_SetValue(pString, value, value.Length);
@@ -784,6 +810,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Context_ExecuteCode(V8Context.Handle hContext, StdString.Ptr pResourceName, StdString.Ptr pSourceMapUrl, ulong uniquId, DocumentKind documentKind, IntPtr pDocumentInfo, StdString.Ptr pCode, bool evaluate, V8Value.Ptr pResult)
+            {
+                V8Context_ExecuteCode(hContext, pResourceName, pSourceMapUrl, uniquId, documentKind, pDocumentInfo, pCode, evaluate, pResult);
+            }
+
             V8Script.Handle IV8SplitProxyNative.V8Context_Compile(V8Context.Handle hContext, string resourceName, string sourceMapUrl, ulong uniqueId, DocumentKind documentKind, IntPtr pDocumentInfo, string code)
             {
                 using (var resourceNameScope = StdString.CreateScope(resourceName))
@@ -981,6 +1012,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Object_GetNamedProperty(V8Object.Handle hObject, StdString.Ptr pName, V8Value.Ptr pValue)
+            {
+                V8Object_GetNamedProperty(hObject, pName, pValue);
+            }
+
             bool IV8SplitProxyNative.V8Object_TryGetNamedProperty(V8Object.Handle hObject, string name, out object value)
             {
                 using (var nameScope = StdString.CreateScope(name))
@@ -1070,6 +1106,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Object_Invoke(V8Object.Handle hObject, bool asConstructor, StdV8ValueArray.Ptr pArgs, V8Value.Ptr pResult)
+            {
+                V8Object_Invoke(hObject, asConstructor, pArgs, pResult);
+            }
+
             object IV8SplitProxyNative.V8Object_InvokeMethod(V8Object.Handle hObject, string name, object[] args)
             {
                 using (var nameScope = StdString.CreateScope(name))
@@ -1092,6 +1133,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                     V8Object_GetArrayBufferOrViewInfo(hObject, arrayBufferScope.Value, out offset, out size, out length);
                     arrayBuffer = (IV8Object)V8Value.Get(arrayBufferScope.Value);
                 }
+            }
+
+            void IV8SplitProxyNative.V8Object_GetArrayBufferOrViewInfo(V8Object.Handle hObject, V8Value.Ptr pArrayBuffer, out ulong offset, out ulong size, out ulong length)
+            {
+                V8Object_GetArrayBufferOrViewInfo(hObject, pArrayBuffer, out offset, out size, out length);
             }
 
             void IV8SplitProxyNative.V8Object_InvokeWithArrayBufferOrViewData(V8Object.Handle hObject, IntPtr pAction)
@@ -2225,6 +2271,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         #endregion
 
         
+
         #region Nested type: Impl_Windows_X64
 
         private sealed class Impl_Windows_X64 : IV8SplitProxyNative
@@ -2265,6 +2312,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 return Marshal.PtrToStringUni(pValue, length);
             }
 
+            void IV8SplitProxyNative.StdString_GetValue(StdString.Ptr pString, out IntPtr value, out int length)
+            {
+                value = StdString_GetValue(pString, out length);
+            }
+
             void IV8SplitProxyNative.StdString_SetValue(StdString.Ptr pString, string value)
             {
                 StdString_SetValue(pString, value, value.Length);
@@ -2917,6 +2969,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Context_ExecuteCode(V8Context.Handle hContext, StdString.Ptr pResourceName, StdString.Ptr pSourceMapUrl, ulong uniquId, DocumentKind documentKind, IntPtr pDocumentInfo, StdString.Ptr pCode, bool evaluate, V8Value.Ptr pResult)
+            {
+                V8Context_ExecuteCode(hContext, pResourceName, pSourceMapUrl, uniquId, documentKind, pDocumentInfo, pCode, evaluate, pResult);
+            }
+
             V8Script.Handle IV8SplitProxyNative.V8Context_Compile(V8Context.Handle hContext, string resourceName, string sourceMapUrl, ulong uniqueId, DocumentKind documentKind, IntPtr pDocumentInfo, string code)
             {
                 using (var resourceNameScope = StdString.CreateScope(resourceName))
@@ -3114,6 +3171,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Object_GetNamedProperty(V8Object.Handle hObject, StdString.Ptr pName, V8Value.Ptr pValue)
+            {
+                V8Object_GetNamedProperty(hObject, pName, pValue);
+            }
+
             bool IV8SplitProxyNative.V8Object_TryGetNamedProperty(V8Object.Handle hObject, string name, out object value)
             {
                 using (var nameScope = StdString.CreateScope(name))
@@ -3203,6 +3265,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Object_Invoke(V8Object.Handle hObject, bool asConstructor, StdV8ValueArray.Ptr pArgs, V8Value.Ptr pResult)
+            {
+                V8Object_Invoke(hObject, asConstructor, pArgs, pResult);
+            }
+
             object IV8SplitProxyNative.V8Object_InvokeMethod(V8Object.Handle hObject, string name, object[] args)
             {
                 using (var nameScope = StdString.CreateScope(name))
@@ -3225,6 +3292,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                     V8Object_GetArrayBufferOrViewInfo(hObject, arrayBufferScope.Value, out offset, out size, out length);
                     arrayBuffer = (IV8Object)V8Value.Get(arrayBufferScope.Value);
                 }
+            }
+
+            void IV8SplitProxyNative.V8Object_GetArrayBufferOrViewInfo(V8Object.Handle hObject, V8Value.Ptr pArrayBuffer, out ulong offset, out ulong size, out ulong length)
+            {
+                V8Object_GetArrayBufferOrViewInfo(hObject, pArrayBuffer, out offset, out size, out length);
             }
 
             void IV8SplitProxyNative.V8Object_InvokeWithArrayBufferOrViewData(V8Object.Handle hObject, IntPtr pAction)
@@ -4358,6 +4430,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         #endregion
 
         
+
         #region Nested type: Impl_Windows_Arm64
 
         private sealed class Impl_Windows_Arm64 : IV8SplitProxyNative
@@ -4398,6 +4471,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 return Marshal.PtrToStringUni(pValue, length);
             }
 
+            void IV8SplitProxyNative.StdString_GetValue(StdString.Ptr pString, out IntPtr value, out int length)
+            {
+                value = StdString_GetValue(pString, out length);
+            }
+
             void IV8SplitProxyNative.StdString_SetValue(StdString.Ptr pString, string value)
             {
                 StdString_SetValue(pString, value, value.Length);
@@ -5050,6 +5128,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Context_ExecuteCode(V8Context.Handle hContext, StdString.Ptr pResourceName, StdString.Ptr pSourceMapUrl, ulong uniquId, DocumentKind documentKind, IntPtr pDocumentInfo, StdString.Ptr pCode, bool evaluate, V8Value.Ptr pResult)
+            {
+                V8Context_ExecuteCode(hContext, pResourceName, pSourceMapUrl, uniquId, documentKind, pDocumentInfo, pCode, evaluate, pResult);
+            }
+
             V8Script.Handle IV8SplitProxyNative.V8Context_Compile(V8Context.Handle hContext, string resourceName, string sourceMapUrl, ulong uniqueId, DocumentKind documentKind, IntPtr pDocumentInfo, string code)
             {
                 using (var resourceNameScope = StdString.CreateScope(resourceName))
@@ -5247,6 +5330,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Object_GetNamedProperty(V8Object.Handle hObject, StdString.Ptr pName, V8Value.Ptr pValue)
+            {
+                V8Object_GetNamedProperty(hObject, pName, pValue);
+            }
+
             bool IV8SplitProxyNative.V8Object_TryGetNamedProperty(V8Object.Handle hObject, string name, out object value)
             {
                 using (var nameScope = StdString.CreateScope(name))
@@ -5336,6 +5424,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Object_Invoke(V8Object.Handle hObject, bool asConstructor, StdV8ValueArray.Ptr pArgs, V8Value.Ptr pResult)
+            {
+                V8Object_Invoke(hObject, asConstructor, pArgs, pResult);
+            }
+
             object IV8SplitProxyNative.V8Object_InvokeMethod(V8Object.Handle hObject, string name, object[] args)
             {
                 using (var nameScope = StdString.CreateScope(name))
@@ -5358,6 +5451,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                     V8Object_GetArrayBufferOrViewInfo(hObject, arrayBufferScope.Value, out offset, out size, out length);
                     arrayBuffer = (IV8Object)V8Value.Get(arrayBufferScope.Value);
                 }
+            }
+
+            void IV8SplitProxyNative.V8Object_GetArrayBufferOrViewInfo(V8Object.Handle hObject, V8Value.Ptr pArrayBuffer, out ulong offset, out ulong size, out ulong length)
+            {
+                V8Object_GetArrayBufferOrViewInfo(hObject, pArrayBuffer, out offset, out size, out length);
             }
 
             void IV8SplitProxyNative.V8Object_InvokeWithArrayBufferOrViewData(V8Object.Handle hObject, IntPtr pAction)
@@ -6491,6 +6589,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         #endregion
 
         
+
         #region Nested type: Impl_Linux_X64
 
         private sealed class Impl_Linux_X64 : IV8SplitProxyNative
@@ -6531,6 +6630,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 return Marshal.PtrToStringUni(pValue, length);
             }
 
+            void IV8SplitProxyNative.StdString_GetValue(StdString.Ptr pString, out IntPtr value, out int length)
+            {
+                value = StdString_GetValue(pString, out length);
+            }
+
             void IV8SplitProxyNative.StdString_SetValue(StdString.Ptr pString, string value)
             {
                 StdString_SetValue(pString, value, value.Length);
@@ -7183,6 +7287,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Context_ExecuteCode(V8Context.Handle hContext, StdString.Ptr pResourceName, StdString.Ptr pSourceMapUrl, ulong uniquId, DocumentKind documentKind, IntPtr pDocumentInfo, StdString.Ptr pCode, bool evaluate, V8Value.Ptr pResult)
+            {
+                V8Context_ExecuteCode(hContext, pResourceName, pSourceMapUrl, uniquId, documentKind, pDocumentInfo, pCode, evaluate, pResult);
+            }
+
             V8Script.Handle IV8SplitProxyNative.V8Context_Compile(V8Context.Handle hContext, string resourceName, string sourceMapUrl, ulong uniqueId, DocumentKind documentKind, IntPtr pDocumentInfo, string code)
             {
                 using (var resourceNameScope = StdString.CreateScope(resourceName))
@@ -7380,6 +7489,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Object_GetNamedProperty(V8Object.Handle hObject, StdString.Ptr pName, V8Value.Ptr pValue)
+            {
+                V8Object_GetNamedProperty(hObject, pName, pValue);
+            }
+
             bool IV8SplitProxyNative.V8Object_TryGetNamedProperty(V8Object.Handle hObject, string name, out object value)
             {
                 using (var nameScope = StdString.CreateScope(name))
@@ -7469,6 +7583,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Object_Invoke(V8Object.Handle hObject, bool asConstructor, StdV8ValueArray.Ptr pArgs, V8Value.Ptr pResult)
+            {
+                V8Object_Invoke(hObject, asConstructor, pArgs, pResult);
+            }
+
             object IV8SplitProxyNative.V8Object_InvokeMethod(V8Object.Handle hObject, string name, object[] args)
             {
                 using (var nameScope = StdString.CreateScope(name))
@@ -7491,6 +7610,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                     V8Object_GetArrayBufferOrViewInfo(hObject, arrayBufferScope.Value, out offset, out size, out length);
                     arrayBuffer = (IV8Object)V8Value.Get(arrayBufferScope.Value);
                 }
+            }
+
+            void IV8SplitProxyNative.V8Object_GetArrayBufferOrViewInfo(V8Object.Handle hObject, V8Value.Ptr pArrayBuffer, out ulong offset, out ulong size, out ulong length)
+            {
+                V8Object_GetArrayBufferOrViewInfo(hObject, pArrayBuffer, out offset, out size, out length);
             }
 
             void IV8SplitProxyNative.V8Object_InvokeWithArrayBufferOrViewData(V8Object.Handle hObject, IntPtr pAction)
@@ -8624,6 +8748,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         #endregion
 
         
+
         #region Nested type: Impl_Linux_Arm64
 
         private sealed class Impl_Linux_Arm64 : IV8SplitProxyNative
@@ -8664,6 +8789,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 return Marshal.PtrToStringUni(pValue, length);
             }
 
+            void IV8SplitProxyNative.StdString_GetValue(StdString.Ptr pString, out IntPtr value, out int length)
+            {
+                value = StdString_GetValue(pString, out length);
+            }
+
             void IV8SplitProxyNative.StdString_SetValue(StdString.Ptr pString, string value)
             {
                 StdString_SetValue(pString, value, value.Length);
@@ -9316,6 +9446,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Context_ExecuteCode(V8Context.Handle hContext, StdString.Ptr pResourceName, StdString.Ptr pSourceMapUrl, ulong uniquId, DocumentKind documentKind, IntPtr pDocumentInfo, StdString.Ptr pCode, bool evaluate, V8Value.Ptr pResult)
+            {
+                V8Context_ExecuteCode(hContext, pResourceName, pSourceMapUrl, uniquId, documentKind, pDocumentInfo, pCode, evaluate, pResult);
+            }
+
             V8Script.Handle IV8SplitProxyNative.V8Context_Compile(V8Context.Handle hContext, string resourceName, string sourceMapUrl, ulong uniqueId, DocumentKind documentKind, IntPtr pDocumentInfo, string code)
             {
                 using (var resourceNameScope = StdString.CreateScope(resourceName))
@@ -9513,6 +9648,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Object_GetNamedProperty(V8Object.Handle hObject, StdString.Ptr pName, V8Value.Ptr pValue)
+            {
+                V8Object_GetNamedProperty(hObject, pName, pValue);
+            }
+
             bool IV8SplitProxyNative.V8Object_TryGetNamedProperty(V8Object.Handle hObject, string name, out object value)
             {
                 using (var nameScope = StdString.CreateScope(name))
@@ -9602,6 +9742,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Object_Invoke(V8Object.Handle hObject, bool asConstructor, StdV8ValueArray.Ptr pArgs, V8Value.Ptr pResult)
+            {
+                V8Object_Invoke(hObject, asConstructor, pArgs, pResult);
+            }
+
             object IV8SplitProxyNative.V8Object_InvokeMethod(V8Object.Handle hObject, string name, object[] args)
             {
                 using (var nameScope = StdString.CreateScope(name))
@@ -9624,6 +9769,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                     V8Object_GetArrayBufferOrViewInfo(hObject, arrayBufferScope.Value, out offset, out size, out length);
                     arrayBuffer = (IV8Object)V8Value.Get(arrayBufferScope.Value);
                 }
+            }
+
+            void IV8SplitProxyNative.V8Object_GetArrayBufferOrViewInfo(V8Object.Handle hObject, V8Value.Ptr pArrayBuffer, out ulong offset, out ulong size, out ulong length)
+            {
+                V8Object_GetArrayBufferOrViewInfo(hObject, pArrayBuffer, out offset, out size, out length);
             }
 
             void IV8SplitProxyNative.V8Object_InvokeWithArrayBufferOrViewData(V8Object.Handle hObject, IntPtr pAction)
@@ -10757,6 +10907,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         #endregion
 
         
+
         #region Nested type: Impl_Linux_Arm
 
         private sealed class Impl_Linux_Arm : IV8SplitProxyNative
@@ -10797,6 +10948,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 return Marshal.PtrToStringUni(pValue, length);
             }
 
+            void IV8SplitProxyNative.StdString_GetValue(StdString.Ptr pString, out IntPtr value, out int length)
+            {
+                value = StdString_GetValue(pString, out length);
+            }
+
             void IV8SplitProxyNative.StdString_SetValue(StdString.Ptr pString, string value)
             {
                 StdString_SetValue(pString, value, value.Length);
@@ -11449,6 +11605,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Context_ExecuteCode(V8Context.Handle hContext, StdString.Ptr pResourceName, StdString.Ptr pSourceMapUrl, ulong uniquId, DocumentKind documentKind, IntPtr pDocumentInfo, StdString.Ptr pCode, bool evaluate, V8Value.Ptr pResult)
+            {
+                V8Context_ExecuteCode(hContext, pResourceName, pSourceMapUrl, uniquId, documentKind, pDocumentInfo, pCode, evaluate, pResult);
+            }
+
             V8Script.Handle IV8SplitProxyNative.V8Context_Compile(V8Context.Handle hContext, string resourceName, string sourceMapUrl, ulong uniqueId, DocumentKind documentKind, IntPtr pDocumentInfo, string code)
             {
                 using (var resourceNameScope = StdString.CreateScope(resourceName))
@@ -11646,6 +11807,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Object_GetNamedProperty(V8Object.Handle hObject, StdString.Ptr pName, V8Value.Ptr pValue)
+            {
+                V8Object_GetNamedProperty(hObject, pName, pValue);
+            }
+
             bool IV8SplitProxyNative.V8Object_TryGetNamedProperty(V8Object.Handle hObject, string name, out object value)
             {
                 using (var nameScope = StdString.CreateScope(name))
@@ -11735,6 +11901,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Object_Invoke(V8Object.Handle hObject, bool asConstructor, StdV8ValueArray.Ptr pArgs, V8Value.Ptr pResult)
+            {
+                V8Object_Invoke(hObject, asConstructor, pArgs, pResult);
+            }
+
             object IV8SplitProxyNative.V8Object_InvokeMethod(V8Object.Handle hObject, string name, object[] args)
             {
                 using (var nameScope = StdString.CreateScope(name))
@@ -11757,6 +11928,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                     V8Object_GetArrayBufferOrViewInfo(hObject, arrayBufferScope.Value, out offset, out size, out length);
                     arrayBuffer = (IV8Object)V8Value.Get(arrayBufferScope.Value);
                 }
+            }
+
+            void IV8SplitProxyNative.V8Object_GetArrayBufferOrViewInfo(V8Object.Handle hObject, V8Value.Ptr pArrayBuffer, out ulong offset, out ulong size, out ulong length)
+            {
+                V8Object_GetArrayBufferOrViewInfo(hObject, pArrayBuffer, out offset, out size, out length);
             }
 
             void IV8SplitProxyNative.V8Object_InvokeWithArrayBufferOrViewData(V8Object.Handle hObject, IntPtr pAction)
@@ -12890,6 +13066,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         #endregion
 
         
+
         #region Nested type: Impl_OSX_X64
 
         private sealed class Impl_OSX_X64 : IV8SplitProxyNative
@@ -12930,6 +13107,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 return Marshal.PtrToStringUni(pValue, length);
             }
 
+            void IV8SplitProxyNative.StdString_GetValue(StdString.Ptr pString, out IntPtr value, out int length)
+            {
+                value = StdString_GetValue(pString, out length);
+            }
+
             void IV8SplitProxyNative.StdString_SetValue(StdString.Ptr pString, string value)
             {
                 StdString_SetValue(pString, value, value.Length);
@@ -13582,6 +13764,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Context_ExecuteCode(V8Context.Handle hContext, StdString.Ptr pResourceName, StdString.Ptr pSourceMapUrl, ulong uniquId, DocumentKind documentKind, IntPtr pDocumentInfo, StdString.Ptr pCode, bool evaluate, V8Value.Ptr pResult)
+            {
+                V8Context_ExecuteCode(hContext, pResourceName, pSourceMapUrl, uniquId, documentKind, pDocumentInfo, pCode, evaluate, pResult);
+            }
+
             V8Script.Handle IV8SplitProxyNative.V8Context_Compile(V8Context.Handle hContext, string resourceName, string sourceMapUrl, ulong uniqueId, DocumentKind documentKind, IntPtr pDocumentInfo, string code)
             {
                 using (var resourceNameScope = StdString.CreateScope(resourceName))
@@ -13779,6 +13966,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Object_GetNamedProperty(V8Object.Handle hObject, StdString.Ptr pName, V8Value.Ptr pValue)
+            {
+                V8Object_GetNamedProperty(hObject, pName, pValue);
+            }
+
             bool IV8SplitProxyNative.V8Object_TryGetNamedProperty(V8Object.Handle hObject, string name, out object value)
             {
                 using (var nameScope = StdString.CreateScope(name))
@@ -13868,6 +14060,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Object_Invoke(V8Object.Handle hObject, bool asConstructor, StdV8ValueArray.Ptr pArgs, V8Value.Ptr pResult)
+            {
+                V8Object_Invoke(hObject, asConstructor, pArgs, pResult);
+            }
+
             object IV8SplitProxyNative.V8Object_InvokeMethod(V8Object.Handle hObject, string name, object[] args)
             {
                 using (var nameScope = StdString.CreateScope(name))
@@ -13890,6 +14087,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                     V8Object_GetArrayBufferOrViewInfo(hObject, arrayBufferScope.Value, out offset, out size, out length);
                     arrayBuffer = (IV8Object)V8Value.Get(arrayBufferScope.Value);
                 }
+            }
+
+            void IV8SplitProxyNative.V8Object_GetArrayBufferOrViewInfo(V8Object.Handle hObject, V8Value.Ptr pArrayBuffer, out ulong offset, out ulong size, out ulong length)
+            {
+                V8Object_GetArrayBufferOrViewInfo(hObject, pArrayBuffer, out offset, out size, out length);
             }
 
             void IV8SplitProxyNative.V8Object_InvokeWithArrayBufferOrViewData(V8Object.Handle hObject, IntPtr pAction)
@@ -15023,6 +15225,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         #endregion
 
         
+
         #region Nested type: Impl_OSX_Arm64
 
         private sealed class Impl_OSX_Arm64 : IV8SplitProxyNative
@@ -15063,6 +15266,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 return Marshal.PtrToStringUni(pValue, length);
             }
 
+            void IV8SplitProxyNative.StdString_GetValue(StdString.Ptr pString, out IntPtr value, out int length)
+            {
+                value = StdString_GetValue(pString, out length);
+            }
+
             void IV8SplitProxyNative.StdString_SetValue(StdString.Ptr pString, string value)
             {
                 StdString_SetValue(pString, value, value.Length);
@@ -15715,6 +15923,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Context_ExecuteCode(V8Context.Handle hContext, StdString.Ptr pResourceName, StdString.Ptr pSourceMapUrl, ulong uniquId, DocumentKind documentKind, IntPtr pDocumentInfo, StdString.Ptr pCode, bool evaluate, V8Value.Ptr pResult)
+            {
+                V8Context_ExecuteCode(hContext, pResourceName, pSourceMapUrl, uniquId, documentKind, pDocumentInfo, pCode, evaluate, pResult);
+            }
+
             V8Script.Handle IV8SplitProxyNative.V8Context_Compile(V8Context.Handle hContext, string resourceName, string sourceMapUrl, ulong uniqueId, DocumentKind documentKind, IntPtr pDocumentInfo, string code)
             {
                 using (var resourceNameScope = StdString.CreateScope(resourceName))
@@ -15912,6 +16125,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Object_GetNamedProperty(V8Object.Handle hObject, StdString.Ptr pName, V8Value.Ptr pValue)
+            {
+                V8Object_GetNamedProperty(hObject, pName, pValue);
+            }
+
             bool IV8SplitProxyNative.V8Object_TryGetNamedProperty(V8Object.Handle hObject, string name, out object value)
             {
                 using (var nameScope = StdString.CreateScope(name))
@@ -16001,6 +16219,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Object_Invoke(V8Object.Handle hObject, bool asConstructor, StdV8ValueArray.Ptr pArgs, V8Value.Ptr pResult)
+            {
+                V8Object_Invoke(hObject, asConstructor, pArgs, pResult);
+            }
+
             object IV8SplitProxyNative.V8Object_InvokeMethod(V8Object.Handle hObject, string name, object[] args)
             {
                 using (var nameScope = StdString.CreateScope(name))
@@ -16023,6 +16246,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                     V8Object_GetArrayBufferOrViewInfo(hObject, arrayBufferScope.Value, out offset, out size, out length);
                     arrayBuffer = (IV8Object)V8Value.Get(arrayBufferScope.Value);
                 }
+            }
+
+            void IV8SplitProxyNative.V8Object_GetArrayBufferOrViewInfo(V8Object.Handle hObject, V8Value.Ptr pArrayBuffer, out ulong offset, out ulong size, out ulong length)
+            {
+                V8Object_GetArrayBufferOrViewInfo(hObject, pArrayBuffer, out offset, out size, out length);
             }
 
             void IV8SplitProxyNative.V8Object_InvokeWithArrayBufferOrViewData(V8Object.Handle hObject, IntPtr pAction)
@@ -17156,6 +17384,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         #endregion
 
         
+
     }
 }
 

--- a/ClearScript/V8/SplitProxy/V8SplitProxyNative.UWP.Generated.cs
+++ b/ClearScript/V8/SplitProxy/V8SplitProxyNative.UWP.Generated.cs
@@ -4,6 +4,11 @@
 
 
 
+
+
+
+
+
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
@@ -19,35 +24,42 @@ namespace Microsoft.ClearScript.V8.SplitProxy
             var architecture = RuntimeInformation.ProcessArchitecture;
 
             
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 
+
                 if (architecture == Architecture.X86)
                 {
                     return new Impl_Windows_X86();
                 }
 
                 
+
                 if (architecture == Architecture.X64)
                 {
                     return new Impl_Windows_X64();
                 }
 
                 
+
                 if (architecture == Architecture.Arm64)
                 {
                     return new Impl_Windows_Arm64();
                 }
 
                 
+
                 throw new PlatformNotSupportedException("Unsupported process architecture");
             }
 
             
+
             throw new PlatformNotSupportedException("Unsupported operating system");
         }
 
         
+
         #region Nested type: Impl_Windows_X86
 
         private sealed class Impl_Windows_X86 : IV8SplitProxyNative
@@ -88,6 +100,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 return Marshal.PtrToStringUni(pValue, length);
             }
 
+            void IV8SplitProxyNative.StdString_GetValue(StdString.Ptr pString, out IntPtr value, out int length)
+            {
+                value = StdString_GetValue(pString, out length);
+            }
+
             void IV8SplitProxyNative.StdString_SetValue(StdString.Ptr pString, string value)
             {
                 StdString_SetValue(pString, value, value.Length);
@@ -740,6 +757,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Context_ExecuteCode(V8Context.Handle hContext, StdString.Ptr pResourceName, StdString.Ptr pSourceMapUrl, ulong uniquId, DocumentKind documentKind, IntPtr pDocumentInfo, StdString.Ptr pCode, bool evaluate, V8Value.Ptr pResult)
+            {
+                V8Context_ExecuteCode(hContext, pResourceName, pSourceMapUrl, uniquId, documentKind, pDocumentInfo, pCode, evaluate, pResult);
+            }
+
             V8Script.Handle IV8SplitProxyNative.V8Context_Compile(V8Context.Handle hContext, string resourceName, string sourceMapUrl, ulong uniqueId, DocumentKind documentKind, IntPtr pDocumentInfo, string code)
             {
                 using (var resourceNameScope = StdString.CreateScope(resourceName))
@@ -937,6 +959,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Object_GetNamedProperty(V8Object.Handle hObject, StdString.Ptr pName, V8Value.Ptr pValue)
+            {
+                V8Object_GetNamedProperty(hObject, pName, pValue);
+            }
+
             bool IV8SplitProxyNative.V8Object_TryGetNamedProperty(V8Object.Handle hObject, string name, out object value)
             {
                 using (var nameScope = StdString.CreateScope(name))
@@ -1026,6 +1053,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Object_Invoke(V8Object.Handle hObject, bool asConstructor, StdV8ValueArray.Ptr pArgs, V8Value.Ptr pResult)
+            {
+                V8Object_Invoke(hObject, asConstructor, pArgs, pResult);
+            }
+
             object IV8SplitProxyNative.V8Object_InvokeMethod(V8Object.Handle hObject, string name, object[] args)
             {
                 using (var nameScope = StdString.CreateScope(name))
@@ -1048,6 +1080,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                     V8Object_GetArrayBufferOrViewInfo(hObject, arrayBufferScope.Value, out offset, out size, out length);
                     arrayBuffer = (IV8Object)V8Value.Get(arrayBufferScope.Value);
                 }
+            }
+
+            void IV8SplitProxyNative.V8Object_GetArrayBufferOrViewInfo(V8Object.Handle hObject, V8Value.Ptr pArrayBuffer, out ulong offset, out ulong size, out ulong length)
+            {
+                V8Object_GetArrayBufferOrViewInfo(hObject, pArrayBuffer, out offset, out size, out length);
             }
 
             void IV8SplitProxyNative.V8Object_InvokeWithArrayBufferOrViewData(V8Object.Handle hObject, IntPtr pAction)
@@ -2181,6 +2218,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         #endregion
 
         
+
         #region Nested type: Impl_Windows_X64
 
         private sealed class Impl_Windows_X64 : IV8SplitProxyNative
@@ -2221,6 +2259,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 return Marshal.PtrToStringUni(pValue, length);
             }
 
+            void IV8SplitProxyNative.StdString_GetValue(StdString.Ptr pString, out IntPtr value, out int length)
+            {
+                value = StdString_GetValue(pString, out length);
+            }
+
             void IV8SplitProxyNative.StdString_SetValue(StdString.Ptr pString, string value)
             {
                 StdString_SetValue(pString, value, value.Length);
@@ -2873,6 +2916,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Context_ExecuteCode(V8Context.Handle hContext, StdString.Ptr pResourceName, StdString.Ptr pSourceMapUrl, ulong uniquId, DocumentKind documentKind, IntPtr pDocumentInfo, StdString.Ptr pCode, bool evaluate, V8Value.Ptr pResult)
+            {
+                V8Context_ExecuteCode(hContext, pResourceName, pSourceMapUrl, uniquId, documentKind, pDocumentInfo, pCode, evaluate, pResult);
+            }
+
             V8Script.Handle IV8SplitProxyNative.V8Context_Compile(V8Context.Handle hContext, string resourceName, string sourceMapUrl, ulong uniqueId, DocumentKind documentKind, IntPtr pDocumentInfo, string code)
             {
                 using (var resourceNameScope = StdString.CreateScope(resourceName))
@@ -3070,6 +3118,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Object_GetNamedProperty(V8Object.Handle hObject, StdString.Ptr pName, V8Value.Ptr pValue)
+            {
+                V8Object_GetNamedProperty(hObject, pName, pValue);
+            }
+
             bool IV8SplitProxyNative.V8Object_TryGetNamedProperty(V8Object.Handle hObject, string name, out object value)
             {
                 using (var nameScope = StdString.CreateScope(name))
@@ -3159,6 +3212,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Object_Invoke(V8Object.Handle hObject, bool asConstructor, StdV8ValueArray.Ptr pArgs, V8Value.Ptr pResult)
+            {
+                V8Object_Invoke(hObject, asConstructor, pArgs, pResult);
+            }
+
             object IV8SplitProxyNative.V8Object_InvokeMethod(V8Object.Handle hObject, string name, object[] args)
             {
                 using (var nameScope = StdString.CreateScope(name))
@@ -3181,6 +3239,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                     V8Object_GetArrayBufferOrViewInfo(hObject, arrayBufferScope.Value, out offset, out size, out length);
                     arrayBuffer = (IV8Object)V8Value.Get(arrayBufferScope.Value);
                 }
+            }
+
+            void IV8SplitProxyNative.V8Object_GetArrayBufferOrViewInfo(V8Object.Handle hObject, V8Value.Ptr pArrayBuffer, out ulong offset, out ulong size, out ulong length)
+            {
+                V8Object_GetArrayBufferOrViewInfo(hObject, pArrayBuffer, out offset, out size, out length);
             }
 
             void IV8SplitProxyNative.V8Object_InvokeWithArrayBufferOrViewData(V8Object.Handle hObject, IntPtr pAction)
@@ -4314,6 +4377,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         #endregion
 
         
+
         #region Nested type: Impl_Windows_Arm64
 
         private sealed class Impl_Windows_Arm64 : IV8SplitProxyNative
@@ -4354,6 +4418,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 return Marshal.PtrToStringUni(pValue, length);
             }
 
+            void IV8SplitProxyNative.StdString_GetValue(StdString.Ptr pString, out IntPtr value, out int length)
+            {
+                value = StdString_GetValue(pString, out length);
+            }
+
             void IV8SplitProxyNative.StdString_SetValue(StdString.Ptr pString, string value)
             {
                 StdString_SetValue(pString, value, value.Length);
@@ -5006,6 +5075,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Context_ExecuteCode(V8Context.Handle hContext, StdString.Ptr pResourceName, StdString.Ptr pSourceMapUrl, ulong uniquId, DocumentKind documentKind, IntPtr pDocumentInfo, StdString.Ptr pCode, bool evaluate, V8Value.Ptr pResult)
+            {
+                V8Context_ExecuteCode(hContext, pResourceName, pSourceMapUrl, uniquId, documentKind, pDocumentInfo, pCode, evaluate, pResult);
+            }
+
             V8Script.Handle IV8SplitProxyNative.V8Context_Compile(V8Context.Handle hContext, string resourceName, string sourceMapUrl, ulong uniqueId, DocumentKind documentKind, IntPtr pDocumentInfo, string code)
             {
                 using (var resourceNameScope = StdString.CreateScope(resourceName))
@@ -5203,6 +5277,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Object_GetNamedProperty(V8Object.Handle hObject, StdString.Ptr pName, V8Value.Ptr pValue)
+            {
+                V8Object_GetNamedProperty(hObject, pName, pValue);
+            }
+
             bool IV8SplitProxyNative.V8Object_TryGetNamedProperty(V8Object.Handle hObject, string name, out object value)
             {
                 using (var nameScope = StdString.CreateScope(name))
@@ -5292,6 +5371,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
             }
 
+            void IV8SplitProxyNative.V8Object_Invoke(V8Object.Handle hObject, bool asConstructor, StdV8ValueArray.Ptr pArgs, V8Value.Ptr pResult)
+            {
+                V8Object_Invoke(hObject, asConstructor, pArgs, pResult);
+            }
+
             object IV8SplitProxyNative.V8Object_InvokeMethod(V8Object.Handle hObject, string name, object[] args)
             {
                 using (var nameScope = StdString.CreateScope(name))
@@ -5314,6 +5398,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                     V8Object_GetArrayBufferOrViewInfo(hObject, arrayBufferScope.Value, out offset, out size, out length);
                     arrayBuffer = (IV8Object)V8Value.Get(arrayBufferScope.Value);
                 }
+            }
+
+            void IV8SplitProxyNative.V8Object_GetArrayBufferOrViewInfo(V8Object.Handle hObject, V8Value.Ptr pArrayBuffer, out ulong offset, out ulong size, out ulong length)
+            {
+                V8Object_GetArrayBufferOrViewInfo(hObject, pArrayBuffer, out offset, out size, out length);
             }
 
             void IV8SplitProxyNative.V8Object_InvokeWithArrayBufferOrViewData(V8Object.Handle hObject, IntPtr pAction)
@@ -6447,6 +6536,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         #endregion
 
         
+
     }
 }
 

--- a/ClearScript/V8/SplitProxy/V8SplitProxyNative.cs
+++ b/ClearScript/V8/SplitProxy/V8SplitProxyNative.cs
@@ -8,13 +8,13 @@ namespace Microsoft.ClearScript.V8.SplitProxy
 {
     internal static partial class V8SplitProxyNative
     {
-        private static readonly IV8SplitProxyNative instance = CreateInstance();
+        internal static readonly IV8SplitProxyNative Instance = CreateInstance();
 
         public static string GetVersion()
         {
             try
             {
-                return instance.V8SplitProxyNative_GetVersion();
+                return Instance.V8SplitProxyNative_GetVersion();
             }
             catch (EntryPointNotFoundException)
             {
@@ -25,15 +25,15 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         public static void Invoke(Action<IV8SplitProxyNative> action)
         {
             var previousScheduledException = MiscHelpers.Exchange(ref V8SplitProxyManaged.ScheduledException, null);
-            var previousMethodTable = instance.V8SplitProxyManaged_SetMethodTable(V8SplitProxyManaged.MethodTable);
+            var previousMethodTable = Instance.V8SplitProxyManaged_SetMethodTable(V8SplitProxyManaged.MethodTable);
             try
             {
-                action(instance);
+                action(Instance);
                 ThrowScheduledException();
             }
             finally
             {
-                instance.V8SplitProxyManaged_SetMethodTable(previousMethodTable);
+                Instance.V8SplitProxyManaged_SetMethodTable(previousMethodTable);
                 V8SplitProxyManaged.ScheduledException = previousScheduledException;
             }
         }
@@ -41,43 +41,43 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         public static T Invoke<T>(Func<IV8SplitProxyNative, T> func)
         {
             var previousScheduledException = MiscHelpers.Exchange(ref V8SplitProxyManaged.ScheduledException, null);
-            var previousMethodTable = instance.V8SplitProxyManaged_SetMethodTable(V8SplitProxyManaged.MethodTable);
+            var previousMethodTable = Instance.V8SplitProxyManaged_SetMethodTable(V8SplitProxyManaged.MethodTable);
             try
             {
-                var result = func(instance);
+                var result = func(Instance);
                 ThrowScheduledException();
                 return result;
             }
             finally
             {
-                instance.V8SplitProxyManaged_SetMethodTable(previousMethodTable);
+                Instance.V8SplitProxyManaged_SetMethodTable(previousMethodTable);
                 V8SplitProxyManaged.ScheduledException = previousScheduledException;
             }
         }
 
         public static void InvokeNoThrow(Action<IV8SplitProxyNative> action)
         {
-            var previousMethodTable = instance.V8SplitProxyManaged_SetMethodTable(V8SplitProxyManaged.MethodTable);
+            var previousMethodTable = Instance.V8SplitProxyManaged_SetMethodTable(V8SplitProxyManaged.MethodTable);
             try
             {
-                action(instance);
+                action(Instance);
             }
             finally
             {
-                instance.V8SplitProxyManaged_SetMethodTable(previousMethodTable);
+                Instance.V8SplitProxyManaged_SetMethodTable(previousMethodTable);
             }
         }
 
         public static T InvokeNoThrow<T>(Func<IV8SplitProxyNative, T> func)
         {
-            var previousMethodTable = instance.V8SplitProxyManaged_SetMethodTable(V8SplitProxyManaged.MethodTable);
+            var previousMethodTable = Instance.V8SplitProxyManaged_SetMethodTable(V8SplitProxyManaged.MethodTable);
             try
             {
-                return func(instance);
+                return func(Instance);
             }
             finally
             {
-                instance.V8SplitProxyManaged_SetMethodTable(previousMethodTable);
+                Instance.V8SplitProxyManaged_SetMethodTable(previousMethodTable);
             }
         }
 

--- a/ClearScript/V8/V8ScriptEngine.cs
+++ b/ClearScript/V8/V8ScriptEngine.cs
@@ -1482,10 +1482,21 @@ namespace Microsoft.ClearScript.V8
 
             ScriptInvoke(() =>
             {
-                var marshaledItem = MarshalToScript(item, flags);
-                if (!(marshaledItem is HostItem))
+                object marshaledItem;
+
+#if NETCOREAPP || NETSTANDARD
+                if (item is SplitProxy.IV8HostObject)
                 {
-                    throw new InvalidOperationException("Invalid host item");
+                    marshaledItem = item;
+                }
+                else
+#endif
+                {
+                    marshaledItem = MarshalToScript(item, flags);
+                    if (!(marshaledItem is HostItem))
+                    {
+                        throw new InvalidOperationException("Invalid host item");
+                    }
                 }
 
                 proxy.AddGlobalItem(itemName, marshaledItem, globalMembers);

--- a/ClearScript/V8/V8ScriptEngine.cs
+++ b/ClearScript/V8/V8ScriptEngine.cs
@@ -1053,6 +1053,8 @@ namespace Microsoft.ClearScript.V8
 
         #region internal members
 
+        internal V8ContextProxy ContextProxy => proxy;
+
         internal V8Runtime.Statistics GetRuntimeStatistics()
         {
             VerifyNotDisposed();

--- a/NetCore/ClearScript.V8/ClearScript.V8.csproj
+++ b/NetCore/ClearScript.V8/ClearScript.V8.csproj
@@ -39,11 +39,14 @@
         <Compile Include="..\..\ClearScript\Properties\AssemblyInfo.V8.cs" Link="Properties\AssemblyInfo.V8.cs" />
         <Compile Include="..\..\ClearScript\V8\IV8DebugListener.cs" Link="V8\IV8DebugListener.cs" />
         <Compile Include="..\..\ClearScript\V8\IV8Object.cs" Link="V8\IV8Object.cs" />
+        <Compile Include="..\..\ClearScript\V8\SplitProxy\IV8HostObject.cs" Link="V8\SplitProxy\IV8HostObject.cs" />
         <Compile Include="..\..\ClearScript\V8\SplitProxy\IV8SplitProxyNative.cs" Link="V8\SplitProxy\IV8SplitProxyNative.cs" />
         <Compile Include="..\..\ClearScript\V8\SplitProxy\NativeCallbackImpl.cs" Link="V8\SplitProxy\NativeCallbackImpl.cs" />
+        <Compile Include="..\..\ClearScript\V8\SplitProxy\Uint8Array.cs" Link="V8\SplitProxy\Uint8Array.cs" />
         <Compile Include="..\..\ClearScript\V8\SplitProxy\V8ContextProxyImpl.cs" Link="V8\SplitProxy\V8ContextProxyImpl.cs" />
         <Compile Include="..\..\ClearScript\V8\SplitProxy\V8DebugListenerImpl.cs" Link="V8\SplitProxy\V8DebugListenerImpl.cs" />
         <Compile Include="..\..\ClearScript\V8\SplitProxy\V8EntityHolder.cs" Link="V8\SplitProxy\V8EntityHolder.cs" />
+        <Compile Include="..\..\ClearScript\V8\SplitProxy\V8Function.cs" Link="V8\SplitProxy\V8Function.cs" />
         <Compile Include="..\..\ClearScript\V8\SplitProxy\V8IsolateProxyImpl.cs" Link="V8\SplitProxy\V8IsolateProxyImpl.cs" />
         <Compile Include="..\..\ClearScript\V8\SplitProxy\V8ObjectImpl.cs" Link="V8\SplitProxy\V8ObjectImpl.cs" />
         <Compile Include="..\..\ClearScript\V8\SplitProxy\V8ScriptImpl.cs" Link="V8\SplitProxy\V8ScriptImpl.cs" />

--- a/NetFramework/ClearScript.V8/ClearScript.V8.csproj
+++ b/NetFramework/ClearScript.V8/ClearScript.V8.csproj
@@ -4,6 +4,7 @@
         <TargetFrameworks>net45;net471</TargetFrameworks>
         <RootNamespace>Microsoft.ClearScript.V8</RootNamespace>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -44,9 +45,11 @@
         <Compile Include="..\..\ClearScript\V8\IV8Object.cs" Link="V8\IV8Object.cs" />
         <Compile Include="..\..\ClearScript\V8\SplitProxy\IV8SplitProxyNative.cs" Link="V8\SplitProxy\IV8SplitProxyNative.cs" />
         <Compile Include="..\..\ClearScript\V8\SplitProxy\NativeCallbackImpl.cs" Link="V8\SplitProxy\NativeCallbackImpl.cs" />
+        <Compile Include="..\..\ClearScript\V8\SplitProxy\Uint8Array.cs" Link="V8\SplitProxy\Uint8Array.cs" />
         <Compile Include="..\..\ClearScript\V8\SplitProxy\V8ContextProxyImpl.cs" Link="V8\SplitProxy\V8ContextProxyImpl.cs" />
         <Compile Include="..\..\ClearScript\V8\SplitProxy\V8DebugListenerImpl.cs" Link="V8\SplitProxy\V8DebugListenerImpl.cs" />
         <Compile Include="..\..\ClearScript\V8\SplitProxy\V8EntityHolder.cs" Link="V8\SplitProxy\V8EntityHolder.cs" />
+        <Compile Include="..\..\ClearScript\V8\SplitProxy\V8Function.cs" Link="V8\SplitProxy\V8Function.cs" />
         <Compile Include="..\..\ClearScript\V8\SplitProxy\V8IsolateProxyImpl.cs" Link="V8\SplitProxy\V8IsolateProxyImpl.cs" />
         <Compile Include="..\..\ClearScript\V8\SplitProxy\V8ObjectImpl.cs" Link="V8\SplitProxy\V8ObjectImpl.cs" />
         <Compile Include="..\..\ClearScript\V8\SplitProxy\V8ScriptImpl.cs" Link="V8\SplitProxy\V8ScriptImpl.cs" />

--- a/NetStandard/ClearScript.V8/ClearScript.V8.csproj
+++ b/NetStandard/ClearScript.V8/ClearScript.V8.csproj
@@ -38,11 +38,14 @@
         <Compile Include="..\..\ClearScript\Properties\AssemblyInfo.V8.cs" Link="Properties\AssemblyInfo.V8.cs" />
         <Compile Include="..\..\ClearScript\V8\IV8DebugListener.cs" Link="V8\IV8DebugListener.cs" />
         <Compile Include="..\..\ClearScript\V8\IV8Object.cs" Link="V8\IV8Object.cs" />
+        <Compile Include="..\..\ClearScript\V8\SplitProxy\IV8HostObject.cs" Link="V8\SplitProxy\IV8HostObject.cs" />
         <Compile Include="..\..\ClearScript\V8\SplitProxy\IV8SplitProxyNative.cs" Link="V8\SplitProxy\IV8SplitProxyNative.cs" />
         <Compile Include="..\..\ClearScript\V8\SplitProxy\NativeCallbackImpl.cs" Link="V8\SplitProxy\NativeCallbackImpl.cs" />
+        <Compile Include="..\..\ClearScript\V8\SplitProxy\Uint8Array.cs" Link="V8\SplitProxy\Uint8Array.cs" />
         <Compile Include="..\..\ClearScript\V8\SplitProxy\V8ContextProxyImpl.cs" Link="V8\SplitProxy\V8ContextProxyImpl.cs" />
         <Compile Include="..\..\ClearScript\V8\SplitProxy\V8DebugListenerImpl.cs" Link="V8\SplitProxy\V8DebugListenerImpl.cs" />
         <Compile Include="..\..\ClearScript\V8\SplitProxy\V8EntityHolder.cs" Link="V8\SplitProxy\V8EntityHolder.cs" />
+        <Compile Include="..\..\ClearScript\V8\SplitProxy\V8Function.cs" Link="V8\SplitProxy\V8Function.cs" />
         <Compile Include="..\..\ClearScript\V8\SplitProxy\V8IsolateProxyImpl.cs" Link="V8\SplitProxy\V8IsolateProxyImpl.cs" />
         <Compile Include="..\..\ClearScript\V8\SplitProxy\V8ObjectImpl.cs" Link="V8\SplitProxy\V8ObjectImpl.cs" />
         <Compile Include="..\..\ClearScript\V8\SplitProxy\V8ScriptImpl.cs" Link="V8\SplitProxy\V8ScriptImpl.cs" />

--- a/UWP/ClearScript.V8/ClearScript.V8.csproj
+++ b/UWP/ClearScript.V8/ClearScript.V8.csproj
@@ -19,6 +19,7 @@
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -59,9 +60,11 @@
     <Compile Include="..\..\ClearScript\V8\IV8Object.cs" Link="V8\IV8Object.cs" />
     <Compile Include="..\..\ClearScript\V8\SplitProxy\IV8SplitProxyNative.cs" Link="V8\SplitProxy\IV8SplitProxyNative.cs" />
     <Compile Include="..\..\ClearScript\V8\SplitProxy\NativeCallbackImpl.cs" Link="V8\SplitProxy\NativeCallbackImpl.cs" />
+    <Compile Include="..\..\ClearScript\V8\SplitProxy\Uint8Array.cs" Link="V8\SplitProxy\Uint8Array.cs" />
     <Compile Include="..\..\ClearScript\V8\SplitProxy\V8ContextProxyImpl.cs" Link="V8\SplitProxy\V8ContextProxyImpl.cs" />
     <Compile Include="..\..\ClearScript\V8\SplitProxy\V8DebugListenerImpl.cs" Link="V8\SplitProxy\V8DebugListenerImpl.cs" />
     <Compile Include="..\..\ClearScript\V8\SplitProxy\V8EntityHolder.cs" Link="V8\SplitProxy\V8EntityHolder.cs" />
+    <Compile Include="..\..\ClearScript\V8\SplitProxy\V8Function.cs" Link="V8\SplitProxy\V8Function.cs" />
     <Compile Include="..\..\ClearScript\V8\SplitProxy\V8IsolateProxyImpl.cs" Link="V8\SplitProxy\V8IsolateProxyImpl.cs" />
     <Compile Include="..\..\ClearScript\V8\SplitProxy\V8ObjectImpl.cs" Link="V8\SplitProxy\V8ObjectImpl.cs" />
     <Compile Include="..\..\ClearScript\V8\SplitProxy\V8ScriptImpl.cs" Link="V8\SplitProxy\V8ScriptImpl.cs" />


### PR DESCRIPTION
- Add `IV8HostObject` interface for objects to implement
- Add non-allocating versions of some of the `IV8SplitProxyNative` methods
- Create `readonly ref struct` wrappers around various native V8 types